### PR TITLE
feat: allow nullable inventory import fields and lock public registration after initial setup

### DIFF
--- a/src/core/views.py
+++ b/src/core/views.py
@@ -116,27 +116,44 @@ class UserRegisterView(CreateView):
     form_class = UserRegisterForm
     template_name = 'core/register.html'
     success_url = reverse_lazy('core:login')
-    
+
+    def _central_admin_exists(self):
+        """Return True if at least one central admin account already exists."""
+        return UserProfile.objects.filter(is_central_admin=True).exists()
+
+    def dispatch(self, request, *args, **kwargs):
+        """
+        If a central admin already exists, skip normal dispatch entirely
+        and render the locked page immediately — for both GET and POST.
+        """
+        if self._central_admin_exists():
+            return render(request, self.template_name, {'registration_locked': True})
+        return super().dispatch(request, *args, **kwargs)
+
     @transaction.atomic
     def form_valid(self, form):
+        # Double-check at commit time in case of a race condition
+        if self._central_admin_exists():
+            return render(self.request, self.template_name, {'registration_locked': True})
+
         user = form.save()
-        
+
         org_name = form.cleaned_data.get('org_name')
         org = Organisation.objects.create(
-            name = org_name,
+            name=org_name,
         )
-        
+
         # Create user profile
         first_name = form.cleaned_data.get('first_name')
         last_name = form.cleaned_data.get('last_name')
         UserProfile.objects.create(
-            user=user, 
-            org = org,
-            first_name=first_name, 
-            last_name=last_name, 
+            user=user,
+            org=org,
+            first_name=first_name,
+            last_name=last_name,
             is_central_admin=True
-            )
-        
+        )
+
         login(self.request, user)
         return redirect('landing_page')
     

--- a/src/inventory/views/aura.py
+++ b/src/inventory/views/aura.py
@@ -1439,10 +1439,11 @@ class MasterInventoryImportView(LoginRequiredMixin, CentralAdminRequiredMixin, F
         else:
             df = excel.parse('Items')
             df.columns = [str(c).strip() for c in df.columns]
-            
-            mandatory = ["Item Name","Total Count"]
+
+            # Only Item Name is strictly required as a column
+            mandatory = ["Item Name"]
             missing = [c for c in mandatory if c not in df.columns]
-            
+
             if missing:
                 preview['errors'].append(f"Excel is missing mandatory columns: {missing}")
             else:
@@ -1450,37 +1451,52 @@ class MasterInventoryImportView(LoginRequiredMixin, CentralAdminRequiredMixin, F
                     rownum = idx + 2
                     row_errors = []
 
+                    # ── Item Name (required) ──────────────────────────────────
                     name = str(row.get('Item Name', '')).strip()
-                    cat_name = str(row.get('Category', '')).strip()
-                    brand_name = str(row.get('Brand', '')).strip()
-                    
                     if not name or name.lower() == 'nan':
-                        row_errors.append('Item Name is missing.')
-                    if not cat_name or cat_name.lower() == 'nan':
-                        row_errors.append('Category is missing.')
-                    if not brand_name or brand_name.lower() == 'nan':
-                        row_errors.append('Brand is missing.')
+                        row_errors.append('Item Name is required and cannot be empty.')
+                        name = '—'
 
-                    try:
-                        total_count = int(row.get('Total Count', 0))
-                    except (ValueError, TypeError):
-                        total_count = 0
-                        row_errors.append('Total Count must be a whole number.')
+                    # ── Category (optional) ───────────────────────────────────
+                    cat_raw = row.get('Category', None)
+                    cat_str = str(cat_raw).strip() if cat_raw is not None else ''
+                    cat_display = cat_str if (cat_str and cat_str.lower() != 'nan') else '-'
 
-                    try:
-                        from decimal import Decimal, InvalidOperation
-                        cost = Decimal(str(row.get('Cost', 0)))
-                    except (ValueError, TypeError, InvalidOperation):
-                        cost = Decimal('0.00')
-                        row_errors.append('Cost must be a valid decimal number.')
+                    # ── Brand (optional) ──────────────────────────────────────
+                    brand_raw = row.get('Brand', None)
+                    brand_str = str(brand_raw).strip() if brand_raw is not None else ''
+                    brand_display = brand_str if (brand_str and brand_str.lower() != 'nan') else '-'
+
+                    # ── Total Count (optional) ────────────────────────────────
+                    tc_raw = row.get('Total Count', None)
+                    if tc_raw is None or str(tc_raw).strip() == '' or str(tc_raw).lower() == 'nan':
+                        total_count_display = '-'
+                    else:
+                        try:
+                            total_count_display = int(tc_raw)
+                        except (ValueError, TypeError):
+                            total_count_display = '-'
+                            row_errors.append('Total Count must be a whole number if provided.')
+
+                    # ── Cost (optional) ───────────────────────────────────────
+                    cost_raw = row.get('Cost', None)
+                    if cost_raw is None or str(cost_raw).strip() == '' or str(cost_raw).lower() == 'nan':
+                        cost_display = '-'
+                    else:
+                        try:
+                            from decimal import Decimal, InvalidOperation
+                            cost_display = Decimal(str(cost_raw))
+                        except (ValueError, TypeError, InvalidOperation):
+                            cost_display = '-'
+                            row_errors.append('Cost must be a valid decimal number if provided.')
 
                     preview['items'].append({
                         'rownum': rownum,
                         'name': name,
-                        'category': cat_name,
-                        'brand': brand_name,
-                        'total_count': total_count,
-                        'cost': cost,
+                        'category': cat_display,
+                        'brand': brand_display,
+                        'total_count': total_count_display,
+                        'cost': cost_display,
                         'errors': row_errors
                     })
 
@@ -1513,38 +1529,53 @@ class MasterInventoryImportConfirmView(LoginRequiredMixin, CentralAdminRequiredM
 
         import_count = 0
         from decimal import Decimal
-        
+        from inventory.models import Category, Brand
+
         for _, row in df.iterrows():
             name = str(row.get('Item Name', '')).strip()
-            cat_name = str(row.get('Category', '')).strip()
-            brand_name = str(row.get('Brand', '')).strip()
-
             if not name or name.lower() == 'nan':
                 continue
 
-            # Create unassigned category and brand (no room)
-            from inventory.models import Category, Brand
+            # ── Category (optional — fall back to 'Uncategorised') ────────────
+            cat_raw = row.get('Category', None)
+            cat_name = str(cat_raw).strip() if cat_raw is not None else ''
             if cat_name and cat_name.lower() != 'nan':
                 category, _ = Category.objects.get_or_create(
                     organisation=org, room=None, category_name=cat_name)
             else:
+                cat_name = 'Uncategorised'
                 category, _ = Category.objects.get_or_create(
                     organisation=org, room=None, category_name='Uncategorised')
 
+            # ── Brand (optional — fall back to 'Unknown') ─────────────────────
+            brand_raw = row.get('Brand', None)
+            brand_name = str(brand_raw).strip() if brand_raw is not None else ''
             if brand_name and brand_name.lower() != 'nan':
                 brand, _ = Brand.objects.get_or_create(
                     organisation=org, room=None, brand_name=brand_name)
             else:
+                brand_name = 'Unknown'
                 brand, _ = Brand.objects.get_or_create(
                     organisation=org, room=None, brand_name='Unknown')
-                
-            cost_val = row.get('Cost')
+
+            # ── Total Count (optional — fall back to 0) ───────────────────────
+            tc_raw = row.get('Total Count', None)
+            if tc_raw is None or str(tc_raw).strip() == '' or str(tc_raw).lower() == 'nan':
+                total_count = 0
+            else:
+                try:
+                    total_count = int(tc_raw)
+                except (ValueError, TypeError):
+                    total_count = 0
+
+            # ── Cost (optional — stored as None if absent) ────────────────────
+            cost_raw = row.get('Cost', None)
             try:
-                cost = Decimal(str(cost_val)) if cost_val and str(cost_val).lower() not in ('nan','') else None
+                cost = Decimal(str(cost_raw)) if cost_raw is not None and str(cost_raw).lower() not in ('nan', '') else None
             except Exception:
                 cost = None
 
-            # Create unassigned item
+            # ── Create / update unassigned master item ────────────────────────
             Item.objects.update_or_create(
                 organisation=org,
                 room=None,  # Master inventory - unassigned
@@ -1552,7 +1583,7 @@ class MasterInventoryImportConfirmView(LoginRequiredMixin, CentralAdminRequiredM
                 defaults={
                     'category': category,
                     'brand': brand,
-                    'total_count': int(row.get('Total Count', 0)),
+                    'total_count': total_count,
                     'cost': cost,
                     'is_listed': True,
                     'item_description': f"{brand_name} {name} - Master Inventory"

--- a/src/templates/central_admin/master_inventory_import_upload.html
+++ b/src/templates/central_admin/master_inventory_import_upload.html
@@ -163,6 +163,7 @@
             <ul class="mb-0" style="color: #c53030; font-weight: 600;">
                 <li>Sheet name must be exactly <span class="badge bg-danger">Items</span></li>
                 <li>Columns must be: <span class="text-dark">Item Name, Category, Brand, Total Count, Cost</span></li>
+                <li>Rows with empty Category or Brand will be saved as <span class="text-dark">Uncategorised / Unknown</span>. Empty Total Count defaults to <span class="text-dark">0</span>.</li>
                 <li>System will auto-deduplicate Categories and Brands based on these names.</li>
             </ul>
         </div>

--- a/src/templates/central_admin/master_inventory_import_view.html
+++ b/src/templates/central_admin/master_inventory_import_view.html
@@ -221,7 +221,7 @@
                     <div class="col-6">
                         <div class="info-pill w-100">
                             <span class="label-meta">Cost</span>
-                            <span class="val-meta">₹{{ r.cost }}</span>
+                            <span class="val-meta">{% if r.cost == '-' %}-{% else %}₹{{ r.cost }}{% endif %}</span>
                         </div>
                     </div>
                 </div>

--- a/src/templates/core/register.html
+++ b/src/templates/core/register.html
@@ -1,12 +1,216 @@
 {% extends "base.html" %}
 {% load static %}
 {% block title %} | Register{% endblock title %}
+
 {% block content %}
+
+{% if registration_locked %}
+<!-- ═══════════════════════════════════════════════════════════════
+     REGISTRATION LOCKED STATE
+     Shown when a central admin account already exists.
+     The overlay covers the entire viewport — no form is rendered.
+════════════════════════════════════════════════════════════════ -->
+<style>
+    .lock-overlay {
+        position: fixed;
+        inset: 0;
+        background: linear-gradient(135deg, #0f172a 0%, #1e293b 60%, #0f172a 100%);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        z-index: 9999;
+        padding: 20px;
+    }
+
+    .lock-card {
+        background: #ffffff;
+        border-radius: 24px;
+        padding: 52px 48px 44px;
+        max-width: 520px;
+        width: 100%;
+        text-align: center;
+        box-shadow: 0 32px 80px rgba(0, 0, 0, 0.45);
+        animation: lockIn 0.4s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+    }
+
+    @keyframes lockIn {
+        from { opacity: 0; transform: scale(0.88) translateY(24px); }
+        to   { opacity: 1; transform: scale(1)    translateY(0);    }
+    }
+
+    .lock-icon-wrap {
+        width: 88px;
+        height: 88px;
+        background: linear-gradient(135deg, #fee2e2, #fecaca);
+        border-radius: 50%;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        margin-bottom: 28px;
+        box-shadow: 0 8px 24px rgba(239, 68, 68, 0.25);
+    }
+
+    .lock-icon-wrap i {
+        font-size: 2.4rem;
+        color: #dc2626;
+    }
+
+    .lock-card h2 {
+        font-size: 1.65rem;
+        font-weight: 800;
+        color: #0f172a;
+        margin-bottom: 12px;
+        letter-spacing: -0.3px;
+    }
+
+    .lock-card .lock-sub {
+        font-size: 1rem;
+        color: #64748b;
+        line-height: 1.65;
+        margin-bottom: 32px;
+    }
+
+    .lock-card .lock-sub strong {
+        color: #0f172a;
+    }
+
+    .lock-divider {
+        border: none;
+        border-top: 1px solid #e2e8f0;
+        margin: 0 0 28px 0;
+    }
+
+    .lock-info-box {
+        background: #f8fafc;
+        border: 1px solid #e2e8f0;
+        border-radius: 14px;
+        padding: 18px 20px;
+        margin-bottom: 28px;
+        text-align: left;
+    }
+
+    .lock-info-box p {
+        margin: 0;
+        font-size: 0.9rem;
+        color: #475569;
+        display: flex;
+        align-items: flex-start;
+        gap: 10px;
+    }
+
+    .lock-info-box p i {
+        color: #3b82f6;
+        font-size: 1rem;
+        margin-top: 2px;
+        flex-shrink: 0;
+    }
+
+    .lock-actions {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+    }
+
+    .btn-lock-login {
+        background: linear-gradient(135deg, #1d4ed8, #2563eb);
+        color: #ffffff;
+        font-weight: 700;
+        font-size: 1rem;
+        padding: 14px 24px;
+        border-radius: 12px;
+        border: none;
+        text-decoration: none;
+        display: block;
+        transition: opacity 0.2s, transform 0.15s;
+        box-shadow: 0 4px 16px rgba(37, 99, 235, 0.35);
+    }
+
+    .btn-lock-login:hover {
+        opacity: 0.92;
+        transform: translateY(-1px);
+        color: #fff;
+    }
+
+    .btn-lock-back {
+        background: transparent;
+        color: #64748b;
+        font-weight: 600;
+        font-size: 0.92rem;
+        padding: 10px 24px;
+        border-radius: 12px;
+        border: 1px solid #e2e8f0;
+        text-decoration: none;
+        display: block;
+        transition: background 0.18s, color 0.18s;
+    }
+
+    .btn-lock-back:hover {
+        background: #f1f5f9;
+        color: #1e293b;
+    }
+
+    .lock-badge {
+        display: inline-block;
+        background: #fef2f2;
+        border: 1px solid #fecaca;
+        color: #dc2626;
+        font-size: 0.75rem;
+        font-weight: 700;
+        padding: 4px 12px;
+        border-radius: 20px;
+        letter-spacing: 0.8px;
+        text-transform: uppercase;
+        margin-bottom: 20px;
+    }
+</style>
+
+<div class="lock-overlay">
+    <div class="lock-card">
+        <div class="lock-icon-wrap">
+            <i class="bi bi-shield-lock-fill"></i>
+        </div>
+
+        <span class="lock-badge">Registration Closed</span>
+
+        <h2>This system is already set up</h2>
+
+        <p class="lock-sub">
+            A <strong>Central Admin account</strong> already exists for this platform.
+            Public registration is permanently disabled once the system is initialised.
+        </p>
+
+        <hr class="lock-divider">
+
+        <div class="lock-info-box">
+            <p>
+                <i class="bi bi-info-circle-fill"></i>
+                To get access, contact your Central Admin. New accounts (sub-admins, room incharges)
+                can only be created from inside the admin dashboard.
+            </p>
+        </div>
+
+        <div class="lock-actions">
+            <a href="{% url 'core:login' %}" class="btn-lock-login">
+                <i class="bi bi-box-arrow-in-right me-2"></i>Go to Login
+            </a>
+            <a href="{% url 'landing_page' %}" class="btn-lock-back">
+                <i class="bi bi-arrow-left me-1"></i>Back to Home
+            </a>
+        </div>
+    </div>
+</div>
+
+{% else %}
+<!-- ═══════════════════════════════════════════════════════════════
+     NORMAL REGISTRATION FORM
+     Only shown when no central admin exists yet (first-time setup).
+════════════════════════════════════════════════════════════════ -->
 <div class="container d-flex flex-column justify-content-center align-items-center my-3" style="min-height: 70vh;">
     <div class="card shadow-sm p-4" style="max-width: 400px; width: 100%;">
         <div class="text-center">
             <img class="mb-3" src="{% static 'images/logo-icon.svg' %}" width="48" alt="logo">
-            <h3 class="mb-3">Register</h3>
+            <h3 class="mb-1">Initial Setup</h3>
+            <p class="text-muted small mb-3">Create the Central Admin account to get started.</p>
         </div>
         <form method="post">
             {% csrf_token %}
@@ -14,9 +218,11 @@
                 {{ form.as_p|safe }}
             </div>
             <div class="d-grid">
-                <input type="submit" value="Register" class="btn btn-primary"/>
+                <input type="submit" value="Create Account" class="btn btn-primary"/>
             </div>
         </form>
     </div>
 </div>
+{% endif %}
+
 {% endblock content %}


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><p><strong>PR Title:</strong>
<code>feat: allow nullable inventory import fields and lock public registration after initial setup</code></p>
<hr>
<p><strong>Description:</strong></p>
<h2>What changed</h2>
<h3>1. Master Inventory Excel Import — Nullable Fields</h3>
<p>Only <strong>Item Name</strong> is now required when importing items via Excel. Category, Brand, Total Count, and Cost can all be left blank — empty cells show as <code>"-"</code> in the preview and fall back to safe defaults (<code>Uncategorised</code>, <code>Unknown</code>, <code>0</code>, <code>NULL</code>) when saved to the database. Rows are only flagged as errors if a value is present but in the wrong format.</p>
<h3>2. Registration Lock After Initial Setup</h3>
<p>Once a Central Admin account exists, the <code>/register/</code> page is closed to everyone. Visiting it shows a lock screen explaining that new users can only be added by the Central Admin from inside the dashboard, with a redirect to login.</p>
<hr>
<h3>Files Changed</h3>

File | What
-- | --
aura.py | Nullable import logic for preview + DB commit
master_inventory_import_view.html | Fixed ₹- rendering for empty cost
master_inventory_import_upload.html | Updated instructions to reflect only Item Name is required
views.py | Registration lock check in UserRegisterView
register.html | Lock screen UI + first-time setup form

</body></html><!--EndFragment-->
</body>
</html>