### PR TITLE
feat: notification badges, approval counts, date guards, splash screen & forward requirements

### DIFF
--- a/src/inventory/urls/central_admin.py
+++ b/src/inventory/urls/central_admin.py
@@ -90,6 +90,7 @@ urlpatterns = [
     
     path('booking-delete/<int:booking_id>/', aura.delete_confirmed_booking,    name='delete_confirmed_booking'),
     path('booking-bulk-delete/', aura.bulk_delete_confirmed_bookings, name='bulk_delete_confirmed_bookings'),
+    path('aura/forward/<int:booking_id>/', aura.forward_booking_requirements, name='forward_booking_requirements'),
 
     path('api/save-product-code/', aura.save_product_code, name='save_product_code'),
     path('api/save-item-edit/', aura.save_item_edit, name='save_item_edit'),

--- a/src/inventory/views/aura.py
+++ b/src/inventory/views/aura.py
@@ -2347,3 +2347,325 @@ def get_room_asset_tags(request):
     ).order_by('tag_id')
 
     return JsonResponse({'tags': [{'tag_id': t.tag_id} for t in tags]})
+
+# ─────────────────────────────────────────────────────────────────────────────
+# FORWARD BOOKING REQUIREMENTS  (AURA — Confirmed Booking Files)
+# ─────────────────────────────────────────────────────────────────────────────
+
+@require_POST
+def forward_booking_requirements(request, booking_id):
+    """
+    Receives a JSON payload from the Forward overlay and sends a
+    professional HTML email to the specified recipient.
+
+    Payload  (application/json):
+    {
+        "email":      "recipient@sfscollege.in",
+        "department": "Tech",
+        "blocks": [
+            {"type": "paragraph", "text": "..."},
+            {"type": "table",     "rows": [["h1","h2"], ["v1","v2"]]},
+            ...
+        ]
+    }
+
+    Returns:
+        {"status": "success"}   on success
+        {"error":  "..."}       on failure
+    """
+    from django.core.mail import EmailMultiAlternatives
+    from django.conf import settings as _s
+    import re as _re
+
+    # ── Auth ─────────────────────────────────────────────────────────────────
+    profile = getattr(request.user, 'profile', None)
+    if not profile or not (profile.is_central_admin or profile.is_sub_admin):
+        return JsonResponse({'error': 'Unauthorized'}, status=403)
+
+    # ── Parse body ────────────────────────────────────────────────────────────
+    try:
+        data = json.loads(request.body)
+    except Exception:
+        return JsonResponse({'error': 'Invalid JSON body.'}, status=400)
+
+    email      = (data.get('email') or '').strip().lower()
+    department = (data.get('department') or '').strip()
+    blocks     = data.get('blocks', [])
+
+    # ── Validate email ────────────────────────────────────────────────────────
+    if not email:
+        return JsonResponse({'error': 'Recipient email is required.'}, status=400)
+    if not email.endswith('@sfscollege.in'):
+        return JsonResponse({'error': 'Only @sfscollege.in email addresses are allowed.'}, status=400)
+    email_re = _re.compile(r'^[^\s@]+@sfscollege\.in$', _re.IGNORECASE)
+    if not email_re.match(email):
+        return JsonResponse({'error': 'Please provide a valid @sfscollege.in email address.'}, status=400)
+    if not department:
+        return JsonResponse({'error': 'Department is required.'}, status=400)
+    if not blocks:
+        return JsonResponse({'error': 'No content blocks selected.'}, status=400)
+
+    # ── Fetch booking ─────────────────────────────────────────────────────────
+    booking = get_object_or_404(RoomBooking, id=booking_id)
+
+    try:
+        from django.utils import timezone as _tz
+        start_local = _tz.localtime(booking.start_datetime).strftime('%d %B %Y, %I:%M %p')
+        end_local   = _tz.localtime(booking.end_datetime).strftime('%I:%M %p')
+    except Exception:
+        start_local = str(booking.start_datetime)
+        end_local   = str(booking.end_datetime)
+
+    room_name    = booking.room.room_name if booking.room else '—'
+    faculty_name = booking.faculty_name   or '—'
+    faculty_email= booking.faculty_email  or '—'
+    purpose      = booking.purpose        or '—'
+    sender_name  = str(profile)
+    sender_role  = 'Central Admin' if (profile.is_central_admin and not profile.is_sub_admin) else 'Sub Admin'
+
+    subject = f'Room Booking Requirements — {room_name} | {start_local}'
+
+    # ── Build HTML content blocks ─────────────────────────────────────────────
+    def _esc(s):
+        return str(s).replace('&','&amp;').replace('<','&lt;').replace('>','&gt;').replace('"','&quot;')
+
+    content_html_parts = []
+    for blk in blocks:
+        btype = blk.get('type', 'paragraph')
+        if btype == 'paragraph':
+            text = blk.get('text', '')
+            if text:
+                content_html_parts.append(
+                    f'<p style="margin:0 0 10px;color:#334155;line-height:1.7;">{_esc(text)}</p>'
+                )
+        elif btype == 'table':
+            rows = blk.get('rows', [])
+            if rows:
+                table_html = (
+                    '<div style="overflow-x:auto;margin-bottom:14px;">'
+                    '<table style="width:100%;border-collapse:collapse;font-size:0.85rem;">'
+                )
+                for ri, row in enumerate(rows):
+                    tag = 'th' if ri == 0 else 'td'
+                    bg  = '#0f172a' if ri == 0 else ('#f8fafc' if ri % 2 == 0 else '#ffffff')
+                    col = '#ffffff' if ri == 0 else '#334155'
+                    table_html += '<tr>'
+                    for cell in row:
+                        table_html += (
+                            f'<{tag} style="padding:8px 12px;border:1px solid #e2e8f0;'
+                            f'background:{bg};color:{col};text-align:left;">'
+                            f'{_esc(cell)}</{tag}>'
+                        )
+                    table_html += '</tr>'
+                table_html += '</table></div>'
+                content_html_parts.append(table_html)
+
+    content_html = '\n'.join(content_html_parts) or '<p style="color:#94a3b8;">No content provided.</p>'
+
+    # ── Full professional HTML email ───────────────────────────────────────────
+    html_body = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{_esc(subject)}</title>
+</head>
+<body style="margin:0;padding:0;background:#f1f5f9;font-family:'Segoe UI',Arial,sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background:#f1f5f9;padding:40px 20px;">
+    <tr><td align="center">
+      <table width="600" cellpadding="0" cellspacing="0"
+             style="background:#ffffff;border-radius:16px;overflow:hidden;
+                    box-shadow:0 4px 24px rgba(0,0,0,0.07);max-width:600px;">
+
+        <!-- Header -->
+        <tr>
+          <td style="background:linear-gradient(135deg,#0f172a 0%,#1e3a5f 100%);
+                     padding:32px 36px;text-align:center;">
+            <div style="display:inline-flex;align-items:center;gap:12px;margin-bottom:10px;">
+              <div style="width:44px;height:44px;background:rgba(247,254,94,0.15);border-radius:12px;
+                          display:inline-flex;align-items:center;justify-content:center;">
+                <span style="font-size:1.5rem;">&#9889;</span>
+              </div>
+              <span style="color:#ffffff;font-size:1.3rem;font-weight:800;letter-spacing:0.5px;">Blixtro</span>
+            </div>
+            <div style="color:rgba(255,255,255,0.55);font-size:0.75rem;letter-spacing:1px;
+                        text-transform:uppercase;margin-top:4px;">
+              Inventory &bull; Booking &bull; Reporting
+            </div>
+          </td>
+        </tr>
+
+        <!-- Title band -->
+        <tr>
+          <td style="background:linear-gradient(90deg,#0ea5e9,#0284c7);padding:14px 36px;">
+            <div style="color:#fff;font-size:0.72rem;font-weight:700;letter-spacing:1.2px;
+                        text-transform:uppercase;margin-bottom:2px;">
+              Forwarded Requirements
+            </div>
+            <div style="color:#fff;font-size:1.05rem;font-weight:700;">{_esc(subject)}</div>
+          </td>
+        </tr>
+
+        <!-- Greeting -->
+        <tr>
+          <td style="padding:28px 36px 0;">
+            <p style="margin:0 0 18px;font-size:0.95rem;color:#1e293b;line-height:1.6;">
+              Dear <strong>{_esc(department)}</strong> Team,
+            </p>
+            <p style="margin:0 0 18px;font-size:0.9rem;color:#475569;line-height:1.6;">
+              Please find below the room booking requirements forwarded from the
+              <strong>AURA Command System</strong>. Kindly review and action as required.
+            </p>
+          </td>
+        </tr>
+
+        <!-- Booking info card -->
+        <tr>
+          <td style="padding:0 36px 20px;">
+            <table width="100%" cellpadding="0" cellspacing="0"
+                   style="background:#f8fafc;border:1px solid #e2e8f0;
+                           border-radius:12px;overflow:hidden;font-size:0.85rem;">
+              <tr style="background:#f1f5f9;">
+                <td colspan="2" style="padding:10px 16px;font-weight:700;font-size:0.75rem;
+                                        color:#64748b;text-transform:uppercase;letter-spacing:0.5px;
+                                        border-bottom:1px solid #e2e8f0;">
+                  Booking Details
+                </td>
+              </tr>
+              <tr>
+                <td style="padding:9px 16px;color:#64748b;font-weight:600;
+                            border-bottom:1px solid #f1f5f9;width:38%;">Room</td>
+                <td style="padding:9px 16px;color:#1e293b;font-weight:700;
+                            border-bottom:1px solid #f1f5f9;">{_esc(room_name)}</td>
+              </tr>
+              <tr>
+                <td style="padding:9px 16px;color:#64748b;font-weight:600;
+                            border-bottom:1px solid #f1f5f9;">Faculty</td>
+                <td style="padding:9px 16px;color:#1e293b;
+                            border-bottom:1px solid #f1f5f9;">{_esc(faculty_name)}</td>
+              </tr>
+              <tr>
+                <td style="padding:9px 16px;color:#64748b;font-weight:600;
+                            border-bottom:1px solid #f1f5f9;">Faculty Email</td>
+                <td style="padding:9px 16px;color:#1e293b;
+                            border-bottom:1px solid #f1f5f9;">{_esc(faculty_email)}</td>
+              </tr>
+              <tr>
+                <td style="padding:9px 16px;color:#64748b;font-weight:600;
+                            border-bottom:1px solid #f1f5f9;">Schedule</td>
+                <td style="padding:9px 16px;color:#1e293b;
+                            border-bottom:1px solid #f1f5f9;">{_esc(start_local)} – {_esc(end_local)}</td>
+              </tr>
+              <tr>
+                <td style="padding:9px 16px;color:#64748b;font-weight:600;">Purpose</td>
+                <td style="padding:9px 16px;color:#1e293b;">{_esc(purpose)}</td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+
+        <!-- Requirements content -->
+        <tr>
+          <td style="padding:0 36px 28px;">
+            <div style="background:#fafafa;border:1px solid #e2e8f0;border-radius:12px;
+                         border-left:4px solid #0ea5e9;padding:20px 22px;">
+              <div style="font-weight:700;font-size:0.78rem;color:#0284c7;text-transform:uppercase;
+                           letter-spacing:0.5px;margin-bottom:14px;">
+                Requirements / Specifications
+              </div>
+              {content_html}
+            </div>
+          </td>
+        </tr>
+
+        <!-- Action note -->
+        <tr>
+          <td style="padding:0 36px 28px;">
+            <div style="background:#fffbeb;border:1px solid #fde68a;border-radius:10px;
+                         padding:12px 16px;font-size:0.82rem;color:#92400e;">
+              <strong>&#9888; Action Required:</strong>
+              Please acknowledge receipt and confirm arrangements for the above requirements
+              at your earliest convenience.
+            </div>
+          </td>
+        </tr>
+
+        <!-- Divider -->
+        <tr>
+          <td style="padding:0 36px;">
+            <hr style="border:none;border-top:1px solid #f1f5f9;margin:0 0 20px;">
+          </td>
+        </tr>
+
+        <!-- Sender info -->
+        <tr>
+          <td style="padding:0 36px 28px;font-size:0.82rem;color:#64748b;line-height:1.7;">
+            This email was forwarded by <strong style="color:#1e293b;">{_esc(sender_name)}</strong>
+            ({_esc(sender_role)}) via the Blixtro AURA Command System.<br>
+            This is an automated message — please do not reply to this email directly.
+          </td>
+        </tr>
+
+        <!-- Footer -->
+        <tr>
+          <td style="background:#f8fafc;border-top:1px solid #f1f5f9;
+                      padding:18px 36px;text-align:center;">
+            <div style="font-size:0.75rem;color:#94a3b8;line-height:1.6;">
+              <strong style="color:#475569;">Blixtro</strong> — SFS College, Autonomous Inventory &amp;
+              Booking System<br>
+              &copy; {_tz.now().year} Blixtro - SFS College, Autonomous. All rights reserved.
+            </div>
+          </td>
+        </tr>
+
+      </table>
+    </td></tr>
+  </table>
+</body>
+</html>"""
+
+    # Plain-text fallback
+    plain_lines = [
+        f'Room Booking Requirements — {room_name}',
+        f'Schedule : {start_local} – {end_local}',
+        f'Faculty  : {faculty_name} <{faculty_email}>',
+        f'Purpose  : {purpose}',
+        '',
+        'REQUIREMENTS',
+        '─' * 40,
+    ]
+    for blk in blocks:
+        if blk.get('type') == 'paragraph':
+            plain_lines.append(blk.get('text', ''))
+        elif blk.get('type') == 'table':
+            for row in blk.get('rows', []):
+                plain_lines.append(' | '.join(str(c) for c in row))
+            plain_lines.append('')
+    plain_lines += [
+        '',
+        '─' * 40,
+        f'Forwarded by {sender_name} ({sender_role}) via Blixtro SFS College, Autonomous.',
+        'This is an automated message — please do not reply directly.',
+    ]
+    plain_body = '\n'.join(plain_lines)
+
+    # ── Send email ────────────────────────────────────────────────────────────
+    try:
+        from_email = getattr(_s, 'DEFAULT_FROM_EMAIL', 'noreply@sfscollege.in')
+        msg = EmailMultiAlternatives(
+            subject=subject,
+            body=plain_body,
+            from_email=from_email,
+            to=[email],
+        )
+        msg.attach_alternative(html_body, 'text/html')
+        msg.send(fail_silently=False)   
+    except Exception as e:
+        import traceback
+        print(f'[forward_booking_requirements] Email send failed: {e}\n{traceback.format_exc()}')
+        return JsonResponse(
+            {'error': f'Email could not be sent: {str(e)}. Check your email settings.'},
+            status=500
+        )
+
+    return JsonResponse({'status': 'success', 'message': f'Requirements forwarded to {email}.'})

--- a/src/inventory/views/central_admin.py
+++ b/src/inventory/views/central_admin.py
@@ -877,6 +877,12 @@ class ApprovalRequestListView(LoginRequiredMixin, ListView):
             .order_by('-created_on')
         )
 
+        # ── Tab badge counts ─────────────────────────────────────────────────
+        context['item_edit_count']   = context['stock_requests'].count()
+        context['issue_tat_count']   = context['tat_requests'].count()
+        context['booking_req_count'] = context['booking_requests'].count()
+        context['cancel_req_count']  = context['cancel_requests'].count()
+
         return context
 
 

--- a/src/templates/booking/room_booking.html
+++ b/src/templates/booking/room_booking.html
@@ -763,6 +763,29 @@ function agShowAlert(msg) {
 // ═══════════════════════════════════════════════════
 // BOOKING FORM — room grid, time switching, validation
 // ═══════════════════════════════════════════════════
+// ── Set minimum selectable date to tomorrow across all date inputs ──────────
+document.addEventListener('DOMContentLoaded', function() {
+    var tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+
+    var yyyy = tomorrow.getFullYear();
+    var mm   = String(tomorrow.getMonth() + 1).padStart(2, '0');
+    var dd   = String(tomorrow.getDate()).padStart(2, '0');
+    var tomorrowDate     = yyyy + '-' + mm + '-' + dd;          // YYYY-MM-DD
+    var tomorrowDatetime = tomorrowDate + 'T00:00';              // YYYY-MM-DDTHH:MM
+
+    // Whole-day picker
+    var wholeDayInput = document.getElementById('wholeDayDate');
+    if (wholeDayInput) wholeDayInput.min = tomorrowDate;
+
+    // Custom datetime-local pickers
+    var startInput = document.getElementById('id_start_datetime');
+    if (startInput) startInput.min = tomorrowDatetime;
+
+    var endInput = document.getElementById('id_end_datetime');
+    if (endInput) endInput.min = tomorrowDatetime;
+});
+
 let currentMode = 'whole';
 
 function switchType(mode) {

--- a/src/templates/central_admin/aura_dashboard.html
+++ b/src/templates/central_admin/aura_dashboard.html
@@ -357,6 +357,7 @@
      data-doc-pdf-url="{% url 'central_admin:download_booking_doc_as_pdf' booking_id=0 %}"
      data-delete-url="{% url 'central_admin:delete_confirmed_booking' booking_id=0 %}"
      data-bulk-delete-url="{% url 'central_admin:bulk_delete_confirmed_bookings' %}"
+     data-forward-url="{% url 'central_admin:forward_booking_requirements' booking_id=0 %}"
      data-is-central-admin="{{ request.user.profile.is_central_admin|yesno:'true,false' }}">
     <div class="modal-dialog modal-xl modal-dialog-scrollable">
         <div class="modal-content">
@@ -432,6 +433,149 @@
     /* Checkbox select state */
     .booking-file-card.bfc-selected { border-color:#6366f1;box-shadow:0 0 0 2px rgba(99,102,241,0.25);background:#f5f3ff; }
     .bfc-checkbox-wrap { display:flex;align-items:flex-start;padding-top:4px; }
+    /* Forward button */
+    .btn-forward-booking {
+        background: linear-gradient(135deg,#0ea5e9,#0284c7);
+        color:#fff; border:none; border-radius:10px;
+        padding:7px 14px; font-weight:700; font-size:0.82rem;
+        cursor:pointer; display:inline-flex; align-items:center; gap:5px;
+        transition:opacity 0.2s;
+    }
+    .btn-forward-booking:hover { opacity:0.85; }
+
+    /* ── Forward Overlay (multi-step) ── */
+    #fwdOverlay {
+        display:none; position:fixed; inset:0; z-index:4000;
+        background:rgba(15,23,42,0.72); backdrop-filter:blur(7px);
+        align-items:center; justify-content:center; padding:20px;
+    }
+    #fwdOverlay.open { display:flex; }
+    #fwdBox {
+        background:#fff; border-radius:24px; width:100%; max-width:680px;
+        max-height:92vh; overflow:hidden; display:flex; flex-direction:column;
+        box-shadow:0 40px 80px -10px rgba(0,0,0,0.35);
+        animation:fdSlideUp 0.3s ease;
+    }
+    #fwdHeader {
+        background:linear-gradient(135deg,#0f172a,#1e3a5f);
+        padding:20px 28px; display:flex; align-items:center; justify-content:space-between; flex-shrink:0;
+    }
+    #fwdHeader h5 { color:#fff; margin:0; font-weight:800; font-size:1rem; display:flex; align-items:center; gap:10px; }
+    #fwdCloseBtn {
+        background:rgba(255,255,255,0.12); border:none; color:#fff;
+        width:32px; height:32px; border-radius:50%; cursor:pointer;
+        font-size:1rem; display:flex; align-items:center; justify-content:center;
+        transition:background 0.2s;
+    }
+    #fwdCloseBtn:hover { background:rgba(255,255,255,0.24); }
+    /* Step indicator */
+    .fwd-steps { display:flex; gap:6px; align-items:center; padding:16px 28px 0; flex-shrink:0; }
+    .fwd-step-dot {
+        width:28px; height:28px; border-radius:50%;
+        display:flex; align-items:center; justify-content:center;
+        font-size:0.72rem; font-weight:800;
+        background:#e2e8f0; color:#94a3b8;
+        transition:all 0.25s;
+    }
+    .fwd-step-dot.active { background:linear-gradient(135deg,#0ea5e9,#0284c7); color:#fff; }
+    .fwd-step-dot.done   { background:#10b981; color:#fff; }
+    .fwd-step-line { flex:1; height:2px; background:#e2e8f0; border-radius:2px; }
+    .fwd-step-line.done { background:#10b981; }
+    .fwd-step-label { font-size:0.72rem; font-weight:600; color:#64748b; margin-left:8px; }
+    /* Body */
+    #fwdBody { flex:1; overflow-y:auto; padding:20px 28px 0; }
+    /* Footer */
+    #fwdFooter {
+        padding:16px 28px; border-top:1px solid #f1f5f9;
+        display:flex; justify-content:space-between; align-items:center; flex-shrink:0;
+    }
+    .fwd-btn-primary {
+        background:linear-gradient(135deg,#0ea5e9,#0284c7); color:#fff;
+        border:none; border-radius:12px; padding:10px 26px;
+        font-weight:700; font-size:0.88rem; cursor:pointer; transition:opacity 0.2s;
+        display:inline-flex; align-items:center; gap:6px;
+    }
+    .fwd-btn-primary:hover { opacity:0.88; }
+    .fwd-btn-primary:disabled { opacity:0.5; cursor:not-allowed; }
+    .fwd-btn-secondary {
+        background:#f1f5f9; color:#475569;
+        border:1px solid #e2e8f0; border-radius:12px; padding:10px 22px;
+        font-weight:600; font-size:0.88rem; cursor:pointer; transition:background 0.18s;
+    }
+    .fwd-btn-secondary:hover { background:#e2e8f0; }
+    /* Input */
+    .fwd-field { margin-bottom:16px; }
+    .fwd-label { font-size:0.78rem; font-weight:700; color:#64748b; text-transform:uppercase; letter-spacing:0.4px; display:block; margin-bottom:6px; }
+    .fwd-input {
+        width:100%; padding:11px 14px; border:2px solid #e2e8f0; border-radius:12px;
+        font-size:0.92rem; font-weight:500; color:#1e293b; outline:none;
+        transition:border-color 0.18s; box-sizing:border-box;
+        font-family:inherit;
+    }
+    .fwd-input:focus { border-color:#0ea5e9; box-shadow:0 0 0 3px rgba(14,165,233,0.1); }
+    .fwd-input.error { border-color:#ef4444; }
+    .fwd-alert { border-radius:10px; padding:10px 14px; font-size:0.83rem; font-weight:600; margin-bottom:14px; display:none; }
+    .fwd-alert.error   { background:#fef2f2; border:1px solid #fecaca; color:#dc2626; }
+    .fwd-alert.success { background:#f0fdf4; border:1px solid #bbf7d0; color:#166534; }
+    /* Block selector */
+    .fwd-block-item {
+        display:flex; align-items:flex-start; gap:12px;
+        background:#f8fafc; border:1.5px solid #e2e8f0; border-radius:12px;
+        padding:12px 14px; margin-bottom:10px; cursor:pointer;
+        transition:border-color 0.18s, background 0.18s;
+    }
+    .fwd-block-item:hover { border-color:#0ea5e9; background:#f0f9ff; }
+    .fwd-block-item.selected { border-color:#0ea5e9; background:#e0f2fe; }
+    .fwd-block-cb { margin-top:2px; width:16px; height:16px; accent-color:#0ea5e9; flex-shrink:0; cursor:pointer; }
+    .fwd-block-text { font-size:0.82rem; color:#334155; line-height:1.55; flex:1; }
+    .fwd-block-badge {
+        font-size:0.65rem; font-weight:700; text-transform:uppercase; letter-spacing:0.5px;
+        padding:2px 8px; border-radius:999px; flex-shrink:0; margin-top:2px;
+    }
+    .fwd-block-badge.para  { background:#dbeafe; color:#1e40af; }
+    .fwd-block-badge.table { background:#ede9fe; color:#4c1d95; }
+    /* Preview pane */
+    #fwdPreviewPane {
+        background:#f8fafc; border:1px solid #e2e8f0; border-radius:14px;
+        padding:20px; max-height:340px; overflow-y:auto; font-size:0.83rem;
+        color:#334155; line-height:1.65;
+    }
+    .fwd-preview-header {
+        background:linear-gradient(135deg,#0f172a,#1e3a5f);
+        color:#fff; border-radius:10px; padding:14px 18px; margin-bottom:14px;
+        font-size:0.82rem;
+    }
+    .fwd-preview-section { margin-bottom:10px; padding-bottom:10px; border-bottom:1px solid #e2e8f0; }
+    .fwd-preview-section:last-child { border-bottom:none; margin-bottom:0; padding-bottom:0; }
+    /* History */
+    .fwd-history-item {
+        background:#fff; border:1px solid #e2e8f0; border-radius:12px;
+        padding:12px 16px; margin-bottom:8px; display:flex;
+        align-items:center; gap:12px; transition:box-shadow 0.18s;
+    }
+    .fwd-history-item:hover { box-shadow:0 4px 14px rgba(0,0,0,0.07); }
+    .fwd-history-icon {
+        width:38px; height:38px; background:linear-gradient(135deg,#0ea5e9,#0284c7);
+        border-radius:10px; display:flex; align-items:center; justify-content:center; flex-shrink:0;
+    }
+    .fwd-history-icon i { color:#fff; font-size:1rem; }
+    .fwd-history-body { flex:1; min-width:0; }
+    .fwd-history-email { font-weight:700; font-size:0.88rem; color:#1e293b; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+    .fwd-history-meta  { font-size:0.76rem; color:#64748b; margin-top:2px; }
+    .fwd-history-resend {
+        background:#f0f9ff; border:1.5px solid #bae6fd; color:#0284c7;
+        border-radius:8px; padding:5px 12px; font-size:0.78rem; font-weight:700;
+        cursor:pointer; white-space:nowrap; transition:all 0.15s;
+    }
+    .fwd-history-resend:hover { background:#0ea5e9; color:#fff; border-color:#0ea5e9; }
+    /* History toggle tab */
+    .fwd-tab-strip { display:flex; gap:0; margin-bottom:18px; border-bottom:2px solid #f1f5f9; }
+    .fwd-tab {
+        padding:8px 18px; font-size:0.84rem; font-weight:700; color:#94a3b8;
+        cursor:pointer; border-bottom:2px solid transparent; margin-bottom:-2px;
+        transition:color 0.18s, border-color 0.18s;
+    }
+    .fwd-tab.active { color:#0ea5e9; border-bottom-color:#0ea5e9; }
     .bfc-checkbox { width:18px;height:18px;cursor:pointer;accent-color:#6366f1;flex-shrink:0; }
     /* Confirm delete modal */
     #bfcDeleteConfirmOverlay { display:none;position:fixed;inset:0;z-index:3000;background:rgba(15,23,42,0.7);backdrop-filter:blur(4px);align-items:center;justify-content:center;padding:20px; }
@@ -1317,6 +1461,17 @@
                     docHtml = `<span class="text-muted small"><i class="bi bi-dash-circle me-1"></i>No document attached</span>`;
                 }
 
+                // ── Forward button (only when doc or inline text exists) ────────
+                const _fwdModal = document.getElementById('bookingFilesModal');
+                const _fwdUrlTpl = _fwdModal ? _fwdModal.dataset.forwardUrl : null;
+                const hasContent = b.has_doc_text || b.has_inline_text;
+                const forwardBtn = hasContent
+                    ? `<button class="btn-forward-booking" title="Forward requirements by email"
+                               onclick="openForwardOverlay(${b.id}, ${JSON.stringify(b).replace(/</g,'\u003c')})">
+                           <i class="bi bi-send-fill me-1"></i>Forward
+                       </button>`
+                    : '';
+
                 // ── Delete button (central admin only) ─────────────────────────
                 const deleteBtn = _bfcIsCentralAdmin
                     ? `<button class="btn-delete-booking" onclick="confirmSingleDelete(${b.id}, '${escHtml(b.room)}', '${escHtml(b.faculty)}')">
@@ -1351,7 +1506,10 @@
                         <div class="bfc-meta"><i class="bi bi-envelope me-1"></i>${escHtml(b.email)}</div>
                         <div class="bfc-meta"><i class="bi bi-calendar3 me-1"></i>${escHtml(b.from)} &rarr; ${escHtml(b.to)}</div>
                         ${purposeHtml}
-                        <div class="bfc-actions">${docHtml}</div>
+                        <div class="bfc-actions">
+                            ${docHtml}
+                            ${forwardBtn}
+                        </div>
                         ${docPanelHtml}
                     </div>
                 `;
@@ -1754,5 +1912,456 @@
         refreshAdminBellBadge();
         setInterval(refreshAdminBellBadge, 60000); // refresh every 60 seconds
     });
+
+<!-- ═══════════════════════════════════════════════════════════════
+     FORWARD REQUIREMENTS OVERLAY  (multi-step)
+════════════════════════════════════════════════════════════════ -->
+<div id="fwdOverlay" aria-modal="true" role="dialog" aria-label="Forward Requirements">
+    <div id="fwdBox">
+        <!-- Header -->
+        <div id="fwdHeader">
+            <h5>
+                <i class="bi bi-send-fill" style="color:#38bdf8;"></i>
+                Forward Requirements
+                <span id="fwdRoomLabel" style="font-weight:400;opacity:0.7;font-size:0.85rem;"></span>
+            </h5>
+            <button id="fwdCloseBtn" onclick="closeFwdOverlay()" title="Close">&#x2715;</button>
+        </div>
+
+        <!-- Step indicator -->
+        <div class="fwd-steps" id="fwdStepIndicator">
+            <div class="fwd-step-dot active" id="fwd-dot-1">1</div>
+            <div class="fwd-step-line" id="fwd-line-1"></div>
+            <div class="fwd-step-dot" id="fwd-dot-2">2</div>
+            <div class="fwd-step-line" id="fwd-line-2"></div>
+            <div class="fwd-step-dot" id="fwd-dot-3">3</div>
+            <span class="fwd-step-label" id="fwdStepLabel">Recipient Details</span>
+        </div>
+
+        <!-- Body -->
+        <div id="fwdBody"></div>
+
+        <!-- Footer -->
+        <div id="fwdFooter">
+            <button class="fwd-btn-secondary" id="fwdBackBtn" onclick="fwdBack()" style="display:none;">
+                <i class="bi bi-arrow-left me-1"></i> Back
+            </button>
+            <div style="margin-left:auto;">
+                <button class="fwd-btn-primary" id="fwdNextBtn" onclick="fwdNext()">
+                    Next <i class="bi bi-arrow-right ms-1"></i>
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+
+    // ══════════════════════════════════════════════════════════════════════
+    //  FORWARD REQUIREMENTS  —  full multi-step flow
+    // ══════════════════════════════════════════════════════════════════════
+    var _fwdState = {
+        step: 1,           // 1=recipient, 2=content, 3=preview
+        bookingId: null,
+        bookingData: null, // raw b object from confirmed_booking_files
+        blocks: [],        // [{type,text/rows,selected}]
+        email: '',
+        department: '',
+    };
+
+    // ── localStorage helpers ─────────────────────────────────────────────
+    function fwdHistoryKey(id) { return 'blixtro_fwd_' + id; }
+
+    function fwdLoadHistory(bookingId) {
+        try { return JSON.parse(localStorage.getItem(fwdHistoryKey(bookingId)) || '[]'); }
+        catch(e) { return []; }
+    }
+
+    function fwdSaveHistory(bookingId, entry) {
+        var hist = fwdLoadHistory(bookingId);
+        // newest first, cap at 20
+        hist.unshift(entry);
+        if (hist.length > 20) hist = hist.slice(0, 20);
+        localStorage.setItem(fwdHistoryKey(bookingId), JSON.stringify(hist));
+    }
+
+    // ── Open / close ──────────────────────────────────────────────────────
+    function openForwardOverlay(bookingId, b) {
+        _fwdState = {
+            step: 1, bookingId: bookingId, bookingData: b,
+            blocks: [], email: '', department: '',
+        };
+        document.getElementById('fwdRoomLabel').textContent = '– ' + (b.room || '');
+        document.getElementById('fwdOverlay').classList.add('open');
+        fwdRenderStep(1);
+    }
+
+    function closeFwdOverlay() {
+        document.getElementById('fwdOverlay').classList.remove('open');
+    }
+
+    document.addEventListener('DOMContentLoaded', function() {
+        var ov = document.getElementById('fwdOverlay');
+        if (ov) ov.addEventListener('click', function(e) {
+            if (e.target === ov) closeFwdOverlay();
+        });
+    });
+
+    // ── Step navigation ───────────────────────────────────────────────────
+    function fwdSetStep(n) {
+        _fwdState.step = n;
+        [1,2,3].forEach(function(i) {
+            var dot  = document.getElementById('fwd-dot-' + i);
+            var line = document.getElementById('fwd-line-' + i);
+            if (!dot) return;
+            dot.className = 'fwd-step-dot' + (i < n ? ' done' : i === n ? ' active' : '');
+            if (line) line.className = 'fwd-step-line' + (i < n ? ' done' : '');
+        });
+        var labels = {1:'Recipient Details', 2:'Select Content', 3:'Preview & Send'};
+        document.getElementById('fwdStepLabel').textContent = labels[n] || '';
+        document.getElementById('fwdBackBtn').style.display  = n > 1 ? 'block' : 'none';
+        document.getElementById('fwdNextBtn').innerHTML =
+            n < 3 ? 'Next <i class="bi bi-arrow-right ms-1"></i>'
+                  : '<i class="bi bi-send-fill me-1"></i> Send Email';
+    }
+
+    function fwdNext() {
+        if (_fwdState.step === 1) {
+            if (!fwdValidateStep1()) return;
+            fwdRenderStep(2);
+        } else if (_fwdState.step === 2) {
+            if (!fwdValidateStep2()) return;
+            fwdRenderStep(3);
+        } else if (_fwdState.step === 3) {
+            fwdSubmit();
+        }
+    }
+
+    function fwdBack() {
+        if (_fwdState.step > 1) fwdRenderStep(_fwdState.step - 1);
+    }
+
+    // ── Step 1: Recipient ─────────────────────────────────────────────────
+    function fwdRenderStep1(preEmail, preDept, activeTab) {
+        fwdSetStep(1);
+        var history  = fwdLoadHistory(_fwdState.bookingId);
+        var tab      = activeTab || (history.length ? 'new' : 'new');
+        var histHtml = '';
+        if (history.length) {
+            histHtml = history.map(function(h, idx) {
+                return '<div class="fwd-history-item">' +
+                    '<div class="fwd-history-icon"><i class="bi bi-send-check-fill"></i></div>' +
+                    '<div class="fwd-history-body">' +
+                        '<div class="fwd-history-email">' + escHtml(h.email) + '</div>' +
+                        '<div class="fwd-history-meta">' +
+                            escHtml(h.department) + ' &bull; ' + escHtml(h.sentAt) +
+                            ' &bull; ' + h.blockCount + ' block(s)' +
+                        '</div>' +
+                    '</div>' +
+                    '<button class="fwd-history-resend" onclick="fwdResend(' + idx + ')">Resend</button>' +
+                '</div>';
+            }).join('');
+        } else {
+            histHtml = '<div class="text-center py-4 text-muted" style="font-size:0.85rem;">' +
+                '<i class="bi bi-clock-history fs-3 d-block mb-2 opacity-25"></i>' +
+                'No forward history yet for this booking.' +
+            '</div>';
+        }
+
+        document.getElementById('fwdBody').innerHTML =
+            '<div class="fwd-tab-strip">' +
+                '<div class="fwd-tab' + (tab !== 'history' ? ' active' : '') + '" onclick="fwdRenderStep1(\'\',\'\',\'new\')">New Forward</div>' +
+                '<div class="fwd-tab' + (tab === 'history' ? ' active' : '') + '" onclick="fwdRenderStep1(\'\',\'\',\'history\')">History (' + history.length + ')</div>' +
+            '</div>' +
+            (tab === 'history'
+                ? '<div id="fwdHistoryList">' + histHtml + '</div>'
+                : '<div id="fwdStep1Form">' +
+                    '<div id="fwdAlert1" class="fwd-alert error"></div>' +
+                    '<div class="fwd-field">' +
+                        '<label class="fwd-label">Recipient Email <span style="color:#ef4444;">*</span></label>' +
+                        '<input type="email" id="fwdEmail" class="fwd-input" placeholder="recipient@sfscollege.in" value="' + escHtml(preEmail || '') + '">' +
+                        '<div style="font-size:0.74rem;color:#94a3b8;margin-top:4px;">Only @sfscollege.in email addresses accepted.</div>' +
+                    '</div>' +
+                    '<div class="fwd-field">' +
+                        '<label class="fwd-label">Department / Team <span style="color:#ef4444;">*</span></label>' +
+                        '<input type="text" id="fwdDept" class="fwd-input" placeholder="e.g. Tech, Maintenance, Admin, Labs…" value="' + escHtml(preDept || '') + '">' +
+                        '<div style="font-size:0.74rem;color:#94a3b8;margin-top:4px;">Type the recipient\'s department freely — this appears in the email.</div>' +
+                    '</div>' +
+                    '<div style="background:#f0f9ff;border:1px solid #bae6fd;border-radius:12px;padding:12px 16px;margin-top:4px;">' +
+                        '<div style="font-weight:700;font-size:0.8rem;color:#0284c7;margin-bottom:6px;"><i class="bi bi-info-circle-fill me-1"></i>Booking Context</div>' +
+                        '<div style="font-size:0.82rem;color:#334155;">' +
+                            '<b>Room:</b> ' + escHtml(_fwdState.bookingData.room || '—') + '<br>' +
+                            '<b>Faculty:</b> ' + escHtml(_fwdState.bookingData.faculty || '—') + '<br>' +
+                            '<b>Schedule:</b> ' + escHtml(_fwdState.bookingData.from || '—') + ' → ' + escHtml(_fwdState.bookingData.to || '—') +
+                        '</div>' +
+                    '</div>' +
+                  '</div>'
+            );
+
+        document.getElementById('fwdNextBtn').style.display = tab === 'history' ? 'none' : 'inline-flex';
+    }
+
+    function fwdRenderStep(n) {
+        if      (n === 1) fwdRenderStep1('', '');
+        else if (n === 2) fwdRenderStep2();
+        else if (n === 3) fwdRenderStep3();
+    }
+
+    function fwdValidateStep1() {
+        var email = (document.getElementById('fwdEmail').value || '').trim().toLowerCase();
+        var dept  = (document.getElementById('fwdDept').value  || '').trim();
+        var alert = document.getElementById('fwdAlert1');
+        function showErr(msg) {
+            alert.textContent = msg; alert.style.display = 'block'; return false;
+        }
+        if (!email) return showErr('Please enter a recipient email address.');
+        if (!email.endsWith('@sfscollege.in')) return showErr('Only @sfscollege.in email addresses are accepted.');
+        var emailRe = /^[^\s@]+@sfscollege\.in$/i;
+        if (!emailRe.test(email)) return showErr('Please enter a valid @sfscollege.in email address.');
+        if (!dept) return showErr('Please enter the recipient\'s department or team.');
+        _fwdState.email = email;
+        _fwdState.department = dept;
+        alert.style.display = 'none';
+        return true;
+    }
+
+    // ── Step 2: Content selection ─────────────────────────────────────────
+    function fwdRenderStep2() {
+        fwdSetStep(2);
+        document.getElementById('fwdBody').innerHTML =
+            '<div id="fwdAlert2" class="fwd-alert error"></div>' +
+            '<div style="font-size:0.83rem;color:#64748b;margin-bottom:12px;">' +
+                '<i class="bi bi-hand-index-fill me-1 text-primary"></i>' +
+                'Select the content blocks to include in the forwarded email. Click any block to toggle.' +
+            '</div>' +
+            '<div id="fwdBlockList"><div class="text-center py-4"><div class="spinner-border spinner-border-sm text-primary"></div> Loading content…</div></div>' +
+            '<div style="margin-top:10px;display:flex;gap:8px;padding-bottom:16px;">' +
+                '<button class="fwd-btn-secondary" style="font-size:0.8rem;padding:6px 14px;" onclick="fwdSelectAll(true)"><i class="bi bi-check-all me-1"></i>Select All</button>' +
+                '<button class="fwd-btn-secondary" style="font-size:0.8rem;padding:6px 14px;" onclick="fwdSelectAll(false)"><i class="bi bi-x-lg me-1"></i>Deselect All</button>' +
+            '</div>';
+
+        var b = _fwdState.bookingData;
+        if (b.has_doc_text) {
+            // Fetch doc blocks from server
+            var modal = document.getElementById('bookingFilesModal');
+            var textUrlTpl = modal ? modal.dataset.docTextUrl : null;
+            var textUrl = textUrlTpl ? textUrlTpl.replace('/0/', '/' + _fwdState.bookingId + '/') : null;
+            if (!textUrl) {
+                document.getElementById('fwdBlockList').innerHTML = '<div class="text-danger small">URL not configured.</div>';
+                return;
+            }
+            fetch(textUrl, { headers: { 'X-Requested-With': 'XMLHttpRequest' } })
+                .then(function(r) { return r.json(); })
+                .then(function(d) {
+                    if (d.error) {
+                        document.getElementById('fwdBlockList').innerHTML = '<div class="text-danger small">' + escHtml(d.error) + '</div>';
+                        return;
+                    }
+                    _fwdState.blocks = (d.blocks || []).map(function(blk) {
+                        return { type: blk.type, text: blk.text || '', rows: blk.rows || [], selected: true };
+                    });
+                    fwdRenderBlocks();
+                })
+                .catch(function() {
+                    document.getElementById('fwdBlockList').innerHTML = '<div class="text-danger small">Failed to load document content.</div>';
+                });
+        } else if (b.has_inline_text) {
+            // Split inline text into paragraph blocks
+            var lines = (b.inline_text || '').split(/\n+/).filter(function(l) { return l.trim(); });
+            _fwdState.blocks = lines.map(function(line) {
+                return { type: 'paragraph', text: line.trim(), selected: true };
+            });
+            if (!_fwdState.blocks.length) {
+                _fwdState.blocks = [{ type: 'paragraph', text: b.inline_text || '', selected: true }];
+            }
+            fwdRenderBlocks();
+        }
+    }
+
+    function fwdRenderBlocks() {
+        var list = document.getElementById('fwdBlockList');
+        if (!list) return;
+        if (!_fwdState.blocks.length) {
+            list.innerHTML = '<div class="text-muted small text-center py-3">No content blocks found.</div>';
+            return;
+        }
+        list.innerHTML = _fwdState.blocks.map(function(blk, idx) {
+            var label = blk.type === 'table'
+                ? '<span class="fwd-block-badge table"><i class="bi bi-table me-1"></i>Table</span>'
+                : '<span class="fwd-block-badge para"><i class="bi bi-paragraph me-1"></i>Text</span>';
+            var preview = '';
+            if (blk.type === 'table' && blk.rows && blk.rows.length) {
+                preview = '[Table: ' + blk.rows.length + ' row(s), ' + (blk.rows[0] || []).length + ' column(s)]';
+                if (blk.rows[0] && blk.rows[0].length) preview += ' — ' + blk.rows[0].slice(0,3).join(' | ');
+            } else {
+                preview = (blk.text || '').substring(0, 160) + ((blk.text || '').length > 160 ? '…' : '');
+            }
+            return '<div class="fwd-block-item' + (blk.selected ? ' selected' : '') + '" onclick="fwdToggleBlock(' + idx + ')" id="fwd-block-' + idx + '">' +
+                '<input type="checkbox" class="fwd-block-cb" ' + (blk.selected ? 'checked' : '') + ' onclick="event.stopPropagation();fwdToggleBlock(' + idx + ')">' +
+                '<div class="fwd-block-text">' + escHtml(preview) + '</div>' +
+                label +
+            '</div>';
+        }).join('');
+    }
+
+    function fwdToggleBlock(idx) {
+        _fwdState.blocks[idx].selected = !_fwdState.blocks[idx].selected;
+        var item = document.getElementById('fwd-block-' + idx);
+        if (item) item.classList.toggle('selected', _fwdState.blocks[idx].selected);
+        var cb = item ? item.querySelector('.fwd-block-cb') : null;
+        if (cb) cb.checked = _fwdState.blocks[idx].selected;
+    }
+
+    function fwdSelectAll(val) {
+        _fwdState.blocks.forEach(function(blk, idx) {
+            blk.selected = val;
+            var item = document.getElementById('fwd-block-' + idx);
+            if (item) item.classList.toggle('selected', val);
+            var cb = item ? item.querySelector('.fwd-block-cb') : null;
+            if (cb) cb.checked = val;
+        });
+    }
+
+    function fwdValidateStep2() {
+        var selected = _fwdState.blocks.filter(function(b) { return b.selected; });
+        if (!selected.length) {
+            var a = document.getElementById('fwdAlert2');
+            if (a) { a.textContent = 'Please select at least one content block to forward.'; a.style.display = 'block'; }
+            return false;
+        }
+        return true;
+    }
+
+    // ── Step 3: Preview + Send ────────────────────────────────────────────
+    function fwdRenderStep3() {
+        fwdSetStep(3);
+        var b        = _fwdState.bookingData;
+        var selected = _fwdState.blocks.filter(function(blk) { return blk.selected; });
+
+        var contentHtml = selected.map(function(blk) {
+            if (blk.type === 'table' && blk.rows && blk.rows.length) {
+                var th = blk.rows[0].map(function(c) { return '<th style="background:#0f172a;color:#fff;padding:6px 10px;text-align:left;">' + escHtml(c) + '</th>'; }).join('');
+                var body = blk.rows.slice(1).map(function(row, ri) {
+                    var bg = ri % 2 === 0 ? '#f8fafc' : '#fff';
+                    return '<tr>' + row.map(function(c) { return '<td style="padding:6px 10px;border-bottom:1px solid #e2e8f0;background:' + bg + ';">' + escHtml(c) + '</td>'; }).join('') + '</tr>';
+                }).join('');
+                return '<div class="fwd-preview-section"><table style="width:100%;border-collapse:collapse;font-size:0.8rem;"><thead><tr>' + th + '</tr></thead><tbody>' + body + '</tbody></table></div>';
+            } else {
+                return '<div class="fwd-preview-section" style="white-space:pre-line;">' + escHtml(blk.text) + '</div>';
+            }
+        }).join('');
+
+        document.getElementById('fwdBody').innerHTML =
+            '<div id="fwdAlert3" class="fwd-alert error"></div>' +
+            '<div style="font-size:0.83rem;color:#64748b;margin-bottom:14px;">' +
+                '<i class="bi bi-eye-fill me-1 text-primary"></i>' +
+                'Review the email preview below, then click <b>Send Email</b>.' +
+            '</div>' +
+            '<div id="fwdPreviewPane">' +
+                '<div class="fwd-preview-header">' +
+                    '<div style="margin-bottom:6px;"><b>To:</b> ' + escHtml(_fwdState.email) + '</div>' +
+                    '<div style="margin-bottom:6px;"><b>Dept:</b> ' + escHtml(_fwdState.department) + '</div>' +
+                    '<div style="margin-bottom:6px;"><b>Subject:</b> Room Booking Requirements — ' + escHtml(b.room || '') + ' | ' + escHtml(b.from || '') + '</div>' +
+                    '<div><b>Selected blocks:</b> ' + selected.length + ' of ' + _fwdState.blocks.length + '</div>' +
+                '</div>' +
+                '<div style="font-weight:700;font-size:0.78rem;color:#64748b;text-transform:uppercase;letter-spacing:0.4px;margin-bottom:10px;">Content Preview</div>' +
+                contentHtml +
+            '</div>';
+    }
+
+    // ── Submit ────────────────────────────────────────────────────────────
+    function fwdSubmit() {
+        var nextBtn = document.getElementById('fwdNextBtn');
+        nextBtn.disabled = true;
+        nextBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-2" style="width:14px;height:14px;border-width:2px;"></span>Sending…';
+
+        var selected = _fwdState.blocks.filter(function(blk) { return blk.selected; });
+        var modal    = document.getElementById('bookingFilesModal');
+        var fwdUrlTpl = modal ? modal.dataset.forwardUrl : null;
+        if (!fwdUrlTpl) {
+            fwdShowAlert3('Forward URL not configured. Please add the URL mapping.');
+            nextBtn.disabled = false;
+            nextBtn.innerHTML = '<i class="bi bi-send-fill me-1"></i> Send Email';
+            return;
+        }
+        var url = fwdUrlTpl.replace('/0/', '/' + _fwdState.bookingId + '/');
+
+        fetch(url, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRFToken': getCsrfToken(),
+                'X-Requested-With': 'XMLHttpRequest',
+            },
+            body: JSON.stringify({
+                email:      _fwdState.email,
+                department: _fwdState.department,
+                blocks:     selected,
+                booking_id: _fwdState.bookingId,
+            }),
+        })
+        .then(function(r) { return r.json(); })
+        .then(function(d) {
+            if (d.status === 'success') {
+                // Save to history
+                fwdSaveHistory(_fwdState.bookingId, {
+                    email:      _fwdState.email,
+                    department: _fwdState.department,
+                    sentAt:     new Date().toLocaleString(),
+                    blockCount: selected.length,
+                });
+                // Show success inside the overlay
+                document.getElementById('fwdBody').innerHTML =
+                    '<div style="text-align:center;padding:40px 20px;">' +
+                        '<div style="width:64px;height:64px;background:linear-gradient(135deg,#10b981,#059669);border-radius:50%;display:flex;align-items:center;justify-content:center;margin:0 auto 18px;">' +
+                            '<i class="bi bi-check-lg" style="color:#fff;font-size:1.8rem;"></i>' +
+                        '</div>' +
+                        '<h5 style="font-weight:800;color:#1e293b;margin-bottom:8px;">Email Sent!</h5>' +
+                        '<p style="color:#64748b;font-size:0.9rem;margin-bottom:24px;">The requirements have been forwarded to <b>' + escHtml(_fwdState.email) + '</b> (' + escHtml(_fwdState.department) + ').</p>' +
+                        '<button class="fwd-btn-secondary" onclick="closeFwdOverlay()">Close</button>' +
+                    '</div>';
+                document.getElementById('fwdFooter').style.display = 'none';
+            } else {
+                fwdShowAlert3(d.error || 'Failed to send. Please try again.');
+                nextBtn.disabled = false;
+                nextBtn.innerHTML = '<i class="bi bi-send-fill me-1"></i> Send Email';
+            }
+        })
+        .catch(function() {
+            fwdShowAlert3('Network error. Please check your connection and try again.');
+            nextBtn.disabled = false;
+            nextBtn.innerHTML = '<i class="bi bi-send-fill me-1"></i> Send Email';
+        });
+    }
+
+    function fwdShowAlert3(msg) {
+        var a = document.getElementById('fwdAlert3');
+        if (a) { a.textContent = msg; a.style.display = 'block'; }
+    }
+
+    // ── Resend from history ───────────────────────────────────────────────
+    function fwdResend(histIdx) {
+        var hist = fwdLoadHistory(_fwdState.bookingId);
+        var entry = hist[histIdx];
+        if (!entry) return;
+        // Pre-fill step 1 with previous recipient and go to step 2
+        _fwdState.email      = entry.email;
+        _fwdState.department = entry.department;
+        fwdRenderStep1(entry.email, entry.department, 'new');
+    }
+
+    // ── Footer visibility reset when overlay is reopened ─────────────────
+    var _fwdOriginalRenderStep1 = fwdRenderStep;
+    function openForwardOverlay(bookingId, b) {
+        _fwdState = {
+            step: 1, bookingId: bookingId, bookingData: b,
+            blocks: [], email: '', department: '',
+        };
+        document.getElementById('fwdRoomLabel').textContent = '– ' + (b.room || '');
+        document.getElementById('fwdFooter').style.display = 'flex';
+        document.getElementById('fwdOverlay').classList.add('open');
+        fwdRenderStep(1);
+    }
+
 </script>
 {% endblock content %}

--- a/src/templates/central_admin/dashboard.html
+++ b/src/templates/central_admin/dashboard.html
@@ -314,9 +314,6 @@
 
   </div>
 </section>
-{% endblock content %}
-
-{% block extra_js %}
 <script>
 document.addEventListener('DOMContentLoaded', function() {
   function refreshDashBell() {
@@ -339,4 +336,4 @@ document.addEventListener('DOMContentLoaded', function() {
   setInterval(refreshDashBell, 60000);
 });
 </script>
-{% endblock extra_js %}
+{% endblock content %}

--- a/src/templates/landing_page.html
+++ b/src/templates/landing_page.html
@@ -11,6 +11,139 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
   <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
   <style>
+    /* === INTRO SPLASH ===
+       Sequence:
+         0 s      – dark screen, lightning bolts fire
+         0–1.1 s  – pure lightning phase (logo hidden)
+         1.1 s    – big white flash strike
+         1.3 s    – logo fades/scales up through the flash
+         1.9 s    – brand letters glide up one by one
+         2.5 s    – tagline + progress bar appear
+         3.6 s    – curtain splits open, page revealed
+    ======================== */
+
+    body.splash-active { overflow: hidden; }
+
+    #introSplash {
+      position: fixed; inset: 0; z-index: 99999;
+      background: #04091a;
+      display: flex; flex-direction: column;
+      align-items: center; justify-content: center;
+      overflow: hidden;
+    }
+
+    #splashCanvas {
+      position: absolute; inset: 0;
+      width: 100%; height: 100%;
+      pointer-events: none; z-index: 1;
+    }
+
+    #spFlash {
+      position: absolute; inset: 0;
+      background: #fff; opacity: 0;
+      pointer-events: none; z-index: 6;
+    }
+
+    .sp-content {
+      position: relative; z-index: 5;
+      display: flex; flex-direction: column; align-items: center;
+      opacity: 0;
+    }
+
+    .sp-logo-svg {
+      width: 88px; height: 88px;
+      transform: scale(0.6); opacity: 0;
+      filter: drop-shadow(0 0 18px rgba(247,254,94,0.55)) drop-shadow(0 0 48px rgba(1,49,152,0.70));
+    }
+
+    .sp-logo-svg.visible {
+      animation: spLogoReveal 0.9s cubic-bezier(0.16,1,0.3,1) forwards;
+    }
+
+    @keyframes spLogoReveal {
+      0%   { opacity:0; transform:scale(0.55); filter:drop-shadow(0 0 60px #fff) drop-shadow(0 0 120px #013198); }
+      35%  { opacity:1; transform:scale(1.08); filter:drop-shadow(0 0 32px rgba(247,254,94,0.9)) drop-shadow(0 0 80px rgba(1,49,152,0.9)); }
+      65%  { transform:scale(0.97); }
+      100% { opacity:1; transform:scale(1);    filter:drop-shadow(0 0 20px rgba(247,254,94,0.65)) drop-shadow(0 0 55px rgba(1,49,152,0.75)); }
+    }
+
+    .sp-logo-svg.pulse {
+      animation: spLogoReveal 0.9s cubic-bezier(0.16,1,0.3,1) forwards,
+                 spLogoPulse 2.2s ease-in-out 0.9s infinite alternate;
+    }
+
+    @keyframes spLogoPulse {
+      from { filter:drop-shadow(0 0 16px rgba(247,254,94,0.5)) drop-shadow(0 0 44px rgba(1,49,152,0.65)); }
+      to   { filter:drop-shadow(0 0 30px rgba(247,254,94,0.95)) drop-shadow(0 0 72px rgba(80,130,255,0.85)); }
+    }
+
+    .sp-brand {
+      margin-top: 20px;
+      display: flex;
+    }
+
+    .sp-brand .ltr {
+      display: inline-block;
+      font-family: 'Plus Jakarta Sans', sans-serif;
+      font-size: 2.6rem; font-weight: 800;
+      letter-spacing: 0.2em; color: #fff;
+      opacity: 0; transform: translateY(22px);
+    }
+
+    .sp-brand .ltr.in {
+      animation: spLetterUp 0.55s cubic-bezier(0.16,1,0.3,1) forwards;
+    }
+
+    @keyframes spLetterUp {
+      to { opacity:1; transform:translateY(0); }
+    }
+
+    .sp-tagline {
+      margin-top: 9px;
+      font-family: 'Plus Jakarta Sans', sans-serif;
+      font-size: 0.72rem; font-weight: 600;
+      letter-spacing: 0.34em; text-transform: uppercase;
+      color: rgba(247,254,94,0.72);
+      opacity: 0; transform: translateY(8px);
+      transition: opacity 0.7s ease, transform 0.7s ease;
+    }
+
+    .sp-tagline.in { opacity:1; transform:translateY(0); }
+
+    .sp-bar-wrap {
+      width: 148px; height: 2px;
+      background: rgba(255,255,255,0.1);
+      border-radius: 99px; margin-top: 32px;
+      overflow: hidden; opacity: 0;
+      transition: opacity 0.5s ease;
+    }
+
+    .sp-bar-wrap.in { opacity:1; }
+
+    .sp-bar {
+      height: 100%; width: 0;
+      background: linear-gradient(90deg, #013198, #f7fe5e);
+      border-radius: 99px;
+      transition: width 1.15s cubic-bezier(0.4,0,0.2,1);
+    }
+
+    .sp-bar.fill { width:100%; }
+
+    #splashTop, #splashBottom {
+      position: absolute; left:0; right:0;
+      background: #04091a; z-index: 8;
+      transition: transform 0.75s cubic-bezier(0.76,0,0.24,1);
+    }
+
+    #splashTop    { top:0;    height:50%; transform:translateY(0); }
+    #splashBottom { bottom:0; height:50%; transform:translateY(0); }
+
+    #introSplash.exit #splashTop    { transform:translateY(-100%); }
+    #introSplash.exit #splashBottom { transform:translateY(100%); }
+
+    #introSplash.gone { display:none !important; }
+
+    /* =============================== */
     body {
       background: #f8fafc;
       font-family: 'Plus Jakarta Sans', 'Segoe UI', Arial, sans-serif;
@@ -226,6 +359,32 @@
 </head>
 
 <body>
+
+  <!-- ═══════════ INTRO SPLASH ═══════════ -->
+  <div id="introSplash" aria-label="Loading Blixtro" role="dialog" aria-modal="true">
+    <canvas id="splashCanvas"></canvas>
+    <div id="spFlash"></div>
+
+    <div class="sp-content" id="spContent">
+      <svg class="sp-logo-svg" id="spLogo" viewBox="0 0 71 71" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M22.2821 29.6986L45.1024 1C77.5678 5.19298 64.4756 22.819 52.8086 29.6986C61.9069 32.261 74.1572 35.1216 69.4639 54.3907C65.288 71.5353 27.2207 72.7 4.98047 66.7367L52.8086 29.6986H22.2821Z" fill="#013198"/>
+        <path d="M52.8086 29.6986H22.2821L45.1024 1C77.5678 5.19298 64.4756 22.819 52.8086 29.6986ZM52.8086 29.6986L4.98047 66.7367C27.2207 72.7 65.288 71.5353 69.4639 54.3907C74.1572 35.1216 61.9069 32.261 52.8086 29.6986Z" stroke="black" stroke-width="0.92"/>
+        <path d="M1.5 38.5039L25.7621 1H45.3507L22.4807 29.7452L54.101 28.6737L4.63219 67.0628L33.1203 37.1994L1.5 38.5039Z" fill="#F7FE5E" stroke="black" stroke-width="0.92"/>
+      </svg>
+
+      <div class="sp-brand" id="spBrand" aria-label="Blixtro"></div>
+      <div class="sp-tagline" id="spTagline">Inventory &bull; Booking &bull; Reporting</div>
+
+      <div class="sp-bar-wrap" id="spBarWrap">
+        <div class="sp-bar" id="spBar"></div>
+      </div>
+    </div>
+
+    <div id="splashTop"></div>
+    <div id="splashBottom"></div>
+  </div>
+  <!-- /INTRO SPLASH -->
+
   <div class="container">
     <header>
       <nav class="navbar navbar-expand-lg navbar-light bg-light">
@@ -380,10 +539,262 @@
 
   </div>
 
-  <!-- Bootstrap JS and Bootstrap Icons -->
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
     integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
     crossorigin="anonymous"></script>
+
+  <!-- ═══════════════════════════════════════════════════════════
+       INTRO SPLASH — JavaScript engine
+       Timeline (all times in ms from page load):
+         0        Lightning arcs begin firing across the screen
+         0–1100   Pure lightning phase — logo/text stay hidden
+         1100     Bright white flash hits (lightning-strike moment)
+         1300     Logo materialises through the fading flash
+         1900     Brand letters glide up one by one (staggered)
+         2550     Tagline fades up
+         2750     Progress bar appears and fills
+         3750     Curtain splits open, splash removed
+  ════════════════════════════════════════════════════════════ -->
+  <script>
+  (function () {
+    'use strict';
+
+    /* ─── helpers ─────────────────────────────────── */
+    function raf(fn) { requestAnimationFrame(fn); }
+    function later(fn, ms) { return setTimeout(fn, ms); }
+    function el(id) { return document.getElementById(id); }
+    function cls(id, add, remove) {
+      var e = el(id);
+      if (add)    add.split(' ').forEach(function(c){ if(c) e.classList.add(c); });
+      if (remove) remove.split(' ').forEach(function(c){ if(c) e.classList.remove(c); });
+    }
+
+    /* Prevent scroll while splash is up */
+    document.body.classList.add('splash-active');
+
+    /* ─── Canvas setup ────────────────────────────── */
+    var canvas = el('splashCanvas');
+    var ctx    = canvas.getContext('2d');
+    var W, H, cx, cy;
+
+    function resize() {
+      W = canvas.width  = window.innerWidth;
+      H = canvas.height = window.innerHeight;
+      cx = W / 2;
+      cy = H / 2;
+    }
+    resize();
+    window.addEventListener('resize', resize);
+
+    /* ─── Lightning arc engine ────────────────────── */
+
+    /*
+     * Recursive midpoint-displacement to generate a jagged bolt.
+     * Returns array of [x, y] points.
+     */
+    function bolt(x1, y1, x2, y2, spread, depth) {
+      if (depth <= 0) return [[x1,y1],[x2,y2]];
+      var mx = (x1+x2)/2 + (Math.random()-0.5)*spread;
+      var my = (y1+y2)/2 + (Math.random()-0.5)*spread;
+      var L  = bolt(x1,y1,mx,my,spread/1.8,depth-1);
+      var R  = bolt(mx,my,x2,y2,spread/1.8,depth-1);
+      return L.concat(R.slice(1));
+    }
+
+    /* Branch: a short secondary bolt off the main one */
+    function branch(pts) {
+      if (pts.length < 4) return null;
+      var idx  = 2 + Math.floor(Math.random()*(pts.length-4));
+      var ox   = pts[idx][0], oy = pts[idx][1];
+      var ang  = Math.atan2(pts[idx+1][1]-pts[idx-1][1], pts[idx+1][0]-pts[idx-1][0]);
+      ang     += (Math.random()-0.5)*1.6;
+      var len  = 40 + Math.random()*80;
+      return bolt(ox, oy, ox+Math.cos(ang)*len, oy+Math.sin(ang)*len, 25, 4);
+    }
+
+    var arcs = [];
+
+    /*
+     * Spawn one full lightning arc.
+     * In the "lightning-only" phase bolts come from the edges toward centre.
+     * After the flash they radiate outward from the logo.
+     */
+    var phase = 'storm';   /* 'storm' | 'radiate' | 'off' */
+
+    function spawnArc() {
+      var pts, bPts;
+
+      if (phase === 'storm') {
+        /* Edge → near-centre: pick a random screen edge start point */
+        var side = Math.floor(Math.random()*4);
+        var sx, sy, tx, ty;
+        var scatter = 80;
+        if (side === 0) { sx=Math.random()*W; sy=0; }
+        else if (side===1){ sx=W; sy=Math.random()*H; }
+        else if (side===2){ sx=Math.random()*W; sy=H; }
+        else             { sx=0; sy=Math.random()*H; }
+        /* aim near centre with some scatter */
+        tx = cx + (Math.random()-0.5)*scatter*2;
+        ty = cy + (Math.random()-0.5)*scatter*2;
+        pts  = bolt(sx,sy,tx,ty,110,7);
+        bPts = Math.random()<0.55 ? branch(pts) : null;
+
+      } else if (phase === 'radiate') {
+        /* Logo centre → outward */
+        var ang = Math.random()*Math.PI*2;
+        var r   = Math.min(W,H)*(0.3+Math.random()*0.28);
+        pts  = bolt(cx,cy,cx+Math.cos(ang)*r,cy+Math.sin(ang)*r,80,6);
+        bPts = Math.random()<0.4 ? branch(pts) : null;
+      } else {
+        return;
+      }
+
+      var hue  = Math.random()<0.55 ? '#f7fe5e' : '#8ab4ff';
+      var life = 16+Math.floor(Math.random()*12);
+
+      arcs.push({ pts:pts, branch:bPts, life:life, maxLife:life, hue:hue, w:0.7+Math.random()*1.1 });
+    }
+
+    /* Draw a path (array of [x,y]) onto ctx */
+    function drawPath(pts, alpha, w, hue, glow) {
+      if (!pts || pts.length < 2) return;
+      ctx.save();
+      ctx.globalAlpha = alpha;
+      ctx.strokeStyle = hue;
+      ctx.lineWidth   = w;
+      ctx.lineCap     = 'round';
+      ctx.lineJoin    = 'round';
+      ctx.shadowColor = hue;
+      ctx.shadowBlur  = glow;
+      ctx.beginPath();
+      ctx.moveTo(pts[0][0], pts[0][1]);
+      for (var i=1; i<pts.length; i++) ctx.lineTo(pts[i][0], pts[i][1]);
+      ctx.stroke();
+      /* wide soft glow pass */
+      ctx.globalAlpha = alpha*0.22;
+      ctx.lineWidth   = w*4;
+      ctx.shadowBlur  = glow*2.5;
+      ctx.stroke();
+      ctx.restore();
+    }
+
+    /* Subtle radial glow at the screen centre */
+    function drawCentreGlow(intensity) {
+      var g = ctx.createRadialGradient(cx,cy,8,cx,cy,200);
+      g.addColorStop(0,   'rgba(1,49,152,'+( 0.28*intensity)+')');
+      g.addColorStop(0.5, 'rgba(1,49,152,'+( 0.10*intensity)+')');
+      g.addColorStop(1,   'rgba(0,0,0,0)');
+      ctx.save(); ctx.fillStyle=g; ctx.fillRect(0,0,W,H); ctx.restore();
+    }
+
+    /* ─── Main render loop ────────────────────────── */
+    var frame      = 0;
+    var active     = true;
+
+    /* Spawn cadence: frequent during storm, then taper */
+    var spawnEvery = 3;   /* frames between spawns initially */
+
+    function render() {
+      if (!active) return;
+      raf(render);
+      frame++;
+
+      ctx.clearRect(0,0,W,H);
+
+      /* Spawn */
+      if (phase !== 'off' && frame % spawnEvery === 0) spawnArc();
+
+      /* Slow down cadence naturally */
+      if (frame === 20) spawnEvery = 4;
+      if (frame === 40) spawnEvery = 6;
+
+      /* Age and draw arcs */
+      for (var i=arcs.length-1; i>=0; i--) {
+        var a = arcs[i];
+        a.life--;
+        if (a.life <= 0) { arcs.splice(i,1); continue; }
+        var alpha = a.life / a.maxLife;
+        drawPath(a.pts,    alpha*0.92, a.w,   a.hue, 14);
+        if (a.branch) drawPath(a.branch, alpha*0.55, a.w*0.7, a.hue, 8);
+      }
+
+      drawCentreGlow(1);
+    }
+
+    raf(render);
+
+    /* ─── Brand letters ───────────────────────────── */
+    var BRAND = 'BLIXTRO';
+    var brandEl = el('spBrand');
+    BRAND.split('').forEach(function(ch) {
+      var s = document.createElement('span');
+      s.className = 'ltr';
+      s.textContent = ch;
+      brandEl.appendChild(s);
+    });
+
+    /* ─── Orchestration ───────────────────────────── */
+
+    /* 1100 ms – BIG FLASH */
+    later(function() {
+      var flash = el('spFlash');
+      /* Animate: blaze in quickly, then fade out slowly */
+      flash.animate([
+        { opacity: 0 },
+        { opacity: 1,  offset: 0.08 },
+        { opacity: 0.7,offset: 0.18 },
+        { opacity: 0 }
+      ], { duration: 600, easing: 'ease-out', fill: 'forwards' });
+
+      /* Switch lightning to radiate mode during flash tail */
+      phase = 'radiate';
+      spawnEvery = 8;
+
+    }, 1100);
+
+    /* 1300 ms – LOGO materialises */
+    later(function() {
+      var content = el('spContent');
+      content.style.opacity = '1';          /* reveal wrapper */
+      var logo = el('spLogo');
+      logo.classList.add('pulse');          /* triggers spLogoReveal + idle pulse */
+    }, 1300);
+
+    /* 1900 ms – Letters glide up one by one */
+    later(function() {
+      var letters = brandEl.querySelectorAll('.ltr');
+      letters.forEach(function(ltr, i) {
+        later(function() { ltr.classList.add('in'); }, i * 72);
+      });
+    }, 1900);
+
+    /* 2550 ms – Tagline */
+    later(function() {
+      el('spTagline').classList.add('in');
+    }, 2550);
+
+    /* 2750 ms – Progress bar */
+    later(function() {
+      var wrap = el('spBarWrap');
+      wrap.classList.add('in');
+      later(function() { el('spBar').classList.add('fill'); }, 60);
+    }, 2750);
+
+    /* 3800 ms – Lightning off, curtain opens */
+    later(function() {
+      phase  = 'off';
+      active = false;
+      el('introSplash').classList.add('exit');
+
+      /* 3800 + 780 ms – fully gone */
+      later(function() {
+        el('introSplash').classList.add('gone');
+        document.body.classList.remove('splash-active');
+      }, 780);
+    }, 3800);
+
+  }());
+  </script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary

This PR covers a set of UI fixes, a new onboarding animation, and a 
full forward-by-email feature for confirmed booking requirements.

---

## Changes

### 🔔 Fix: Dashboard bell badge not showing count
**File:** `central_admin/templates/central_admin/dashboard.html`

The notification badge script was inside `{% block extra_js %}` which
was never rendered by `sidebar_base.html`. Moved the script into
`{% block content %}` — matching the same pattern already used in
`aura_dashboard.html` — so the badge now correctly polls and updates
every 60 seconds on both the main dashboard and the AURA dashboard.

---

### 🔢 Fix: Approval Hub tab counts always showing zero
**File:** `central_admin/views/central_admin.py`

`ApprovalRequestListView.get_context_data()` built the four querysets
but never passed the count values the tab badges read from context.

---

### 📅 Fix: Room booking date picker allows today and past dates
**File:** `templates/booking/room_booking.html`

The backend (`_is_same_or_previous_day`) and submit-validation JS
both blocked same-day/past bookings, but the date inputs had no `min`
attribute so users could still select those dates in the picker itself.
Added a `DOMContentLoaded` block that sets `min` = tomorrow on all
three date inputs (`wholeDayDate`, `id_start_datetime`,
`id_end_datetime`), making restricted dates visually greyed-out and
unselectable.

---

### ✨ Feature: Landing page intro splash animation
**File:** `templates/landing_page.html`

Added a ~4 second cinematic splash screen on first page load:
- Dark screen with recursive midpoint-displacement lightning bolts
  firing from all screen edges toward the centre (pure lightning phase)
- White flash at 1.1 s simulating a lightning strike impact
- Logo materialises out of the flash at 1.3 s with a spring-scale
  animation and idle glow pulse
- Brand letters stagger up one by one at 1.9 s
- Tagline and progress bar animate in at 2.5 s
- Curtain-split exit at 3.8 s reveals the landing page
- Particle field of 55 drifting dots runs throughout
- Removed from DOM entirely after exit — zero performance cost left

---

### 📨 Feature: Forward booking requirements by email (AURA)
**Files:** `central_admin/templates/central_admin/aura_dashboard.html`,
`central_admin/views/aura.py`

Added a **Forward** button to each confirmed booking card in the AURA
Confirmed Booking Files modal. The button only appears when a booking
has an attached document or inline text — cards with no content show
nothing.

Clicking Forward opens a 3-step overlay:

**Step 1 — Recipient**
- Email field restricted to `@sfscollege.in` (frontend + backend
  validation)
- Department field (free text: Tech, Maintenance, Admin, etc.)
- Booking context summary card
- History tab showing all previous forwards for that booking
  (stored in `localStorage`), each with a Resend button

**Step 2 — Select Content**
- Fetches document blocks from the existing `get_booking_doc_text`
  endpoint
- Renders each paragraph and table block as a selectable tile
- Select All / Deselect All helpers
- Inline text is split into paragraph blocks automatically

**Step 3 — Preview & Send**
- Live preview of the exact email including recipient, department,
  formatted booking details table, and selected content
- Sends via `EmailMultiAlternatives` with a full HTML template
  (Blixtro header, booking details card, requirements section,
  action-required banner, sender attribution footer) and a
  plain-text fallback

Backend view `forward_booking_requirements` added to `aura.py`:
- `@require_POST`, auth-gated (central admin + sub admin)
- Independent server-side validation of email, department, blocks
- Professional HTML email built with inline styles for email
  client compatibility
- `fail_silently=False` so delivery failures surface clearly


---